### PR TITLE
Updated JSS_INVENTORY_NAME to match iTerm.app

### DIFF
--- a/iTerm2/iTerm2.jss.recipe
+++ b/iTerm2/iTerm2.jss.recipe
@@ -15,7 +15,7 @@
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
 		<key>JSS_INVENTORY_NAME</key>
-		<string>iTerm</string>
+		<string>iTerm.app</string>
 		<key>NAME</key>
 		<string>iTerm2</string>
 		<key>POLICY_CATEGORY</key>


### PR DESCRIPTION
The smart group in JSS currently doesn't find the iTerm.app due to an incomplete name being supplied.